### PR TITLE
Fixed an issue causing memory values to be reported incorrectly.

### DIFF
--- a/src/system/memory/memory_windows.cpp
+++ b/src/system/memory/memory_windows.cpp
@@ -24,7 +24,7 @@ iware::system::memory_t iware::system::memory() noexcept {
 	if(!GlobalMemoryStatusEx(&mem))
 		return {};
 
-	return {mem.ullTotalPhys, mem.ullAvailPhys, mem.ullTotalVirtual, mem.ullAvailVirtual};
+	return {mem.ullAvailPhys, mem.ullTotalPhys, mem.ullAvailVirtual, mem.ullTotalVirtual};
 }
 
 


### PR DESCRIPTION
Available memory and total memory values were reversed, causing total memory to be stored in the available memory field in the iware::system::memory_t struct.