### PR TITLE
Git working directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ cmake_minimum_required(VERSION 3.6.0)
 
 
 find_package(Git)
-execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0 OUTPUT_VARIABLE infoware_version WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0 OUTPUT_VARIABLE infoware_version WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} ERROR_QUIET)
 string(STRIP "${infoware_version}" infoware_version)
 if(infoware_version STREQUAL "")
 	set(infoware_version "0.1.0")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ cmake_minimum_required(VERSION 3.6.0)
 
 
 find_package(Git)
-execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0 OUTPUT_VARIABLE infoware_version ERROR_QUIET)
+execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0 OUTPUT_VARIABLE infoware_version WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 string(STRIP "${infoware_version}" infoware_version)
 if(infoware_version STREQUAL "")
 	set(infoware_version "0.1.0")


### PR DESCRIPTION
This PR fixes an issue when you try to build the project as a submodule of another project.

The git command that gets the version normally gets the root projects version which is incorrect, if the git command is run in the source directory of the project then it ensures that it will get this project's version and not the root project's.