### PR TITLE
Fix wrongly handling RPC_E_CHANGED_MODE in Windows

### DIFF
--- a/src/system/OS_info/os_info_windows.cpp
+++ b/src/system/OS_info/os_info_windows.cpp
@@ -28,8 +28,14 @@
 // https://msdn.microsoft.com/en-us/library/aa390423(v=vs.85).aspx
 static std::string version_name() {
 	auto err = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
-	if(FAILED(err) && err != RPC_E_CHANGED_MODE)
+	if(err == RPC_E_CHANGED_MODE) {
+		// User already has initialized COM library by COINIT_APARTMENTTHREADED.
+		err = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+	}
+
+	if(FAILED(err))
 		return {};
+
 	iware::detail::quickscope_wrapper com_uninitialiser{CoUninitialize};
 
 	const auto init_result =


### PR DESCRIPTION
When `CoInitializeEx` returns `RPC_E_CHANGED_MODE`, it DOES NOT increase the reference counter of the COM library. Therefore `version_name()` decreases the reference counter without increment, and the COM library can be unloaded unintentionally.

My code which using infoware initially calls `CoInitializeEx` with `COINIT_APARTMENTTHREADED`, then calls `version_name()` via `iware::system::OS_info()`. In `version_name()` it unloads the COM library, and my following codes fails.

This commit fixes the issue by retrying `CoInitializeEx` with `COINIT_APARTMENTTHREADED`. By doing this, the reference counter of the COM library will be increased successfully.

Refers to:
https://docs.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-coinitializeex