### PR TITLE
Get windows version from WinAPI/registry instead of kernel version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,7 @@ if(WIN32 AND NOT MSVC)
 endif()
 
 if(WIN32)
-	target_link_libraries(infoware PRIVATE gdi32 version Ole32 OleAut32 wbemuuid)
+	target_link_libraries(infoware PRIVATE gdi32 version Ole32 OleAut32 wbemuuid ntdll)
 endif()
 
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ C++ Library for pulling system and hardware information, without hitting the com
 No non-built-in ones by default.<br />
 Some libraries are required for extended functionality. See the [Configurability](#configurability) section below for details.
 
-On Windows one needs to link to `gdi32`, `version`, `Ole32`, `OleAut32` and `wbemuuid`.
+On Windows one needs to link to `gdi32`, `version`, `Ole32`, `OleAut32`, `wbemuuid` and `ntdll`.
 
 A usable `git` binary is required by default, to clone https://github.com/pciutils/pciids.
 	`INFOWARE_PCI_IDS_REPOSITORY` can be set to override that clone URI.

--- a/src/system/OS_info/os_info_windows.cpp
+++ b/src/system/OS_info/os_info_windows.cpp
@@ -25,6 +25,10 @@
 #include <winnt.h>
 #include <winternl.h>
 
+#ifdef _MSC_VER
+#define strtok_r strtok_s
+#endif
+
 extern "C" NTSYSAPI NTSTATUS NTAPI RtlGetVersion(_Out_ PRTL_OSVERSIONINFOW lpVersionInformation);
 
 // Use WIM to acquire Win32_OperatingSystem.Name
@@ -102,8 +106,9 @@ unsigned int build_number() {
 	if(RegQueryValueExA(hkey, "BuildLabEx", nullptr, nullptr, reinterpret_cast<LPBYTE>(&buildlabex[0]), &buildlabex_size))
 		return {};
 
-	auto token = std::strtok(&buildlabex[0], ".");
-	token      = std::strtok(nullptr, ".");
+	char* context = nullptr;
+	auto token = strtok_r(&buildlabex[0], ".", &context);
+	token      = strtok_r(nullptr, ".", &context);
 	return std::strtoul(token ? token : "0", nullptr, 10);
 }
 

--- a/src/system/OS_info/os_info_windows.cpp
+++ b/src/system/OS_info/os_info_windows.cpp
@@ -94,25 +94,17 @@ unsigned int build_number() {
 		return ubr;
 
 	// Fall back to BuildLabEx in the early version of Windows 8.1 and less.
-	constexpr auto buildlabex_name = "BuildLabEx";
-	DWORD buildlabex_size          = 0;
-	if(RegQueryValueExA(hkey, buildlabex_name, nullptr, nullptr, nullptr, &buildlabex_size))
+	DWORD buildlabex_size = 0;
+	if(RegQueryValueExA(hkey, "BuildLabEx", nullptr, nullptr, nullptr, &buildlabex_size))
 		return {};
 
-	std::vector<char> buildlabex_buffer(buildlabex_size);
-	if(RegQueryValueExA(hkey, buildlabex_name, nullptr, nullptr, reinterpret_cast<LPBYTE>(buildlabex_buffer.data()), &buildlabex_size))
+	std::vector<char> buildlabex(buildlabex_size);
+	if(RegQueryValueExA(hkey, "BuildLabEx", nullptr, nullptr, reinterpret_cast<LPBYTE>(buildlabex.data()), &buildlabex_size))
 		return {};
 
-	const std::string buildlabex{buildlabex_buffer.begin(), buildlabex_buffer.end()};
-	const auto first_period = buildlabex.find('.');
-	if(first_period == std::string::npos)
-		return {};
-
-	const auto second_period = buildlabex.find('.', first_period + 1);
-	if(second_period == std::string::npos)
-		return {};
-
-	return std::stoul(buildlabex.substr(first_period + 1, second_period - first_period));
+	auto token = std::strtok(buildlabex.data(), ".");
+	token      = std::strtok(nullptr, ".");
+	return std::strtoul(token ? token : "0", nullptr, 10);
 }
 
 // Get OS version via RtlGetVersion which still works well in Windows 8 and above

--- a/src/system/OS_info/os_info_windows.cpp
+++ b/src/system/OS_info/os_info_windows.cpp
@@ -98,11 +98,11 @@ unsigned int build_number() {
 	if(RegQueryValueExA(hkey, "BuildLabEx", nullptr, nullptr, nullptr, &buildlabex_size))
 		return {};
 
-	std::vector<char> buildlabex(buildlabex_size);
-	if(RegQueryValueExA(hkey, "BuildLabEx", nullptr, nullptr, reinterpret_cast<LPBYTE>(buildlabex.data()), &buildlabex_size))
+	std::string buildlabex(buildlabex_size, {});
+	if(RegQueryValueExA(hkey, "BuildLabEx", nullptr, nullptr, reinterpret_cast<LPBYTE>(&buildlabex[0]), &buildlabex_size))
 		return {};
 
-	auto token = std::strtok(buildlabex.data(), ".");
+	auto token = std::strtok(&buildlabex[0], ".");
 	token      = std::strtok(nullptr, ".");
 	return std::strtoul(token ? token : "0", nullptr, 10);
 }

--- a/src/system/OS_info/os_info_windows.cpp
+++ b/src/system/OS_info/os_info_windows.cpp
@@ -120,9 +120,7 @@ unsigned int build_number() {
 iware::system::OS_info_t iware::system::OS_info() {
 	RTL_OSVERSIONINFOW os_version_info{};
 	os_version_info.dwOSVersionInfoSize = sizeof(os_version_info);
-
-	if(RtlGetVersion(&os_version_info))
-		return {};
+	RtlGetVersion(&os_version_info);
 
 	return {"Windows NT", version_name(), os_version_info.dwMajorVersion, os_version_info.dwMinorVersion, os_version_info.dwBuildNumber, build_number()};
 }


### PR DESCRIPTION
Currently, infoware gets OS version from kernel version in Windows. But the OS version of Windows can be different from the kernel version. For example, I'm using Windows 10 21H1, and its version is `10.0.19043.1165`. But its kernel version(and `OS_info()` of infoware) says `10.0.19041.1151`.

This pull request fixes this issue by getting the OS version from [`RtlGetVersion`](https://docs.microsoft.com/en-us/windows/win32/devnotes/rtlgetversion) and registry key `UBR` or `BuildLabEx`. Although `GetVersionEx` is deprecated, `RtlGetVersion` still works well in the latest Windows. And we can get the build number(in windows, it is called "UBR") from registry key `UBR`(later version of Windows 8.1 and above) or `BuildLabEx`(early version of Windows 8.1 and below).

Refers to: https://github.com/PSAppDeployToolkit/PSAppDeployToolkit/issues/251