### PR TITLE
Use GetNativeSystemInfo instead of GetSystemInfo in iware::cpu::architecture()

### DIFF
--- a/src/cpu/architecture/architecture_windows.cpp
+++ b/src/cpu/architecture/architecture_windows.cpp
@@ -21,7 +21,7 @@
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms724958(v=vs.85).aspx
 iware::cpu::architecture_t iware::cpu::architecture() noexcept {
 	SYSTEM_INFO sysinfo;
-	GetSystemInfo(&sysinfo);
+	GetNativeSystemInfo(&sysinfo);
 
 	switch(sysinfo.wProcessorArchitecture) {
 		case PROCESSOR_ARCHITECTURE_AMD64:


### PR DESCRIPTION
In 64-bit Windows, the OS runs x86 applications in emulation mode(aka WOW64). `GetSystemInfo` returns its emulated information; therefore `iware::cpu::architecture()` says the architecture is x86, although OS is 64-bit. This pull request resolves the issue by calling `GetNativeSystemInfo` instead of `GetSystemInfo`.

Refer to: https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getnativesysteminfo