### PR TITLE
Adding Continuous integration - Github Actions

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -1,0 +1,56 @@
+name: Linux Build
+on: [push, pull_request]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+jobs:
+  linuxbuild:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        platform: [x32, x64]
+        compiler: [gcc, clang]
+        flavor: [ RelWithDebInfo, Coverage ]
+        include:
+        - os: ubuntu-latest
+          platform: x64
+          compiler: clang
+        - os: ubuntu-latest
+          platform: x32
+          compiler: clang
+        - os: ubuntu-latest
+          platform: x64
+          compiler: gcc
+        - os: ubuntu-latest
+          platform: x32
+          compiler: gcc
+    name: Linux InfoWare
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: "recursive"
+
+      - name: Create Build Environment
+        run: cmake -E make_directory ${{runner.workspace}}/build
+
+      - name: Configure CMake
+
+        shell: bash
+        working-directory: ${{runner.workspace}}/build
+        run: |
+          cmake $GITHUB_WORKSPACE ..
+
+      - name: Build Infoware
+        working-directory: ${{runner.workspace}}/build
+        shell: bash
+
+        run: cmake --build . --config $BUILD_TYPE
+
+      - name: Test
+        working-directory: ${{runner.workspace}}/build
+        shell: bash
+
+        run: ctest -C $BUILD_TYPE
+        

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -40,7 +40,7 @@ jobs:
         shell: bash
         working-directory: ${{runner.workspace}}/build
         run: |
-          cmake $GITHUB_WORKSPACE ..
+          cmake $GITHUB_WORKSPACE .. -DINFOWARE_TESTS=ON -DINFOWARE_EXAMPLES=ON
 
       - name: Build Infoware
         working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/window_build.yml
+++ b/.github/workflows/window_build.yml
@@ -6,7 +6,7 @@ env:
 jobs:
   Window:
     runs-on: "windows-latest"
-    name: Windows InfoWare
+    name: Window InfoWare
 
     steps:
     - uses: actions/checkout@v2
@@ -23,10 +23,17 @@ jobs:
       working-directory: ${{runner.workspace}}/build
 
       run: |
-        cmake $GITHUB_WORKSPACE -G "Visual Studio 16 2019"
+        cmake $GITHUB_WORKSPACE -G "Visual Studio 16 2019" -DINFOWARE_TESTS=ON -DINFOWARE_EXAMPLES=ON
      
     - name: Build Infoware
       working-directory: ${{runner.workspace}}/build
       shell: bash
 
       run: cmake --build . --config $BUILD_TYPE
+
+    - name: Test
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+
+      run: ctest -C $BUILD_TYPE
+      

--- a/.github/workflows/window_build.yml
+++ b/.github/workflows/window_build.yml
@@ -1,0 +1,32 @@
+name: Window Build
+on: [push,pull_request]
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  Window:
+    runs-on: "windows-latest"
+    name: Windows InfoWare
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: "recursive"
+
+    - name: Create Build Environment
+
+      run: cmake -E make_directory ${{runner.workspace}}/build
+
+    - name: Configure CMake
+
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+
+      run: |
+        cmake $GITHUB_WORKSPACE -G "Visual Studio 16 2019"
+     
+    - name: Build Infoware
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+
+      run: cmake --build . --config $BUILD_TYPE

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# infoware [![License](https://img.shields.io/badge/license-CC0-green.svg?style=flat)](LICENSE) [![TravisCI build status](https://travis-ci.org/ThePhD/infoware.svg?branch=master)](https://travis-ci.org/ThePhD/infoware) [![AppVeyorCI build status](https://ci.appveyor.com/api/projects/status/github/ThePhD/infoware?branch=master&svg=true)](https://ci.appveyor.com/project/ThePhD/infoware/branch/master)
+# infoware [![License](https://img.shields.io/badge/license-CC0-green.svg?style=flat)](LICENSE) [![Linux Build](https://github.com/ThePhD/infoware/actions/workflows/linux-build.yml/badge.svg)](https://github.com/ThePhD/infoware/actions/workflows/linux-build.yml) [![Window Build](https://github.com/ThePhD/infoware/actions/workflows/window_build.yml/badge.svg)](https://github.com/ThePhD/infoware/actions/workflows/window_build.yml)
 C++ Library for pulling system and hardware information, without hitting the command line.
 
 


### PR DESCRIPTION
My understanding is that both Travis and appveyor are not being used, so I added init CI/CD, using GitHub action instead, As well as adding status badges in the readme.  Currently, I have only added for Linux and Windows.