### PR TITLE
Remove carriage return on CRLF encoded files

### DIFF
--- a/tools/pci_generator.cpp
+++ b/tools/pci_generator.cpp
@@ -60,6 +60,9 @@ int main(int argc, const char** argv) {
 		if(!std::isxdigit(line[tabcount]) || tabcount >= 3)
 			continue;
 
+		if(*line.rbegin() == '\r')  // Remove carriage return if present for CRLF encoded files.
+			line.erase(line.length() - 1);
+
 		char* current_name{};
 		auto current_number = std::strtoull(line.c_str() + tabcount, &current_name, 16);
 		while(std::isspace(*current_name))


### PR DESCRIPTION
The PCI generator will fail to generate a correct header file, because of a new line after the vendor name string, if the pci.ids file were encoded with CRLF.

Though the problem originated from that my git was configured with auto CRLF encoding, so there is no problem with original encoding, but for systems that are using auto CRLF, the compilation will break.