### PR TITLE
Implement Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,29 @@ jobs:
 
       - name: Build Project
         run: cd main/build && ninja
+
+  macos:
+    name: macOS x64 ${{matrix.cfg.name}}
+    runs-on: ${{matrix.cfg.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        cfg:
+          - { os: macos-10.15,  name: "Catalina", dist: true}
+          - { os: macos-11,     name: "Big Sur",  dist: false}
+
+    steps:
+      - name: Checkout infoware
+        uses: actions/checkout@v2
+        with:
+          path: main
+
+      - name: Install homebrew packages
+        run: brew install cmake ninja openssl
+
+      - name: Generate CMake
+        run: mkdir main/build && cd main/build && cmake -DCMAKE_BUILD_TYPE=Release -DINFOWARE_USE_OPENCL=ON -DINFOWARE_EXAMPLES=ON -DINFOWARE_TESTS=ON -G Ninja ..
+
+      - name: Build Project
+        run: cd main/build && ninja
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,29 @@ jobs:
       - name: Build Project
         run: cd main/build && ninja
 
+  windows: # Windows x64 and x86 build matrix
+    strategy:
+      fail-fast: false # Don't cancel other matrix jobs if one fails
+      matrix:
+        cfg:
+        - { name: 32 Bit, arch: x86 }
+        - { name: 64 Bit, arch: x64 }
+
+    name: "Windows MSVC ${{matrix.cfg.name}}"
+    runs-on: windows-2019
+    steps:
+      - name: Checkout infoware
+        uses: actions/checkout@v2
+        with:
+          path: main
+
+      - name: Configure MSBuild
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.cfg.arch }}
+
+      - name: Generate CMake
+        run: mkdir main/build && cd main/build && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DINFOWARE_EXAMPLES=ON -DINFOWARE_TESTS=ON ..
+
+      - name: Build Project
+        run: cmake --build main/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Build Project
         run: cd main/build && ninja
 
+      - name: Run Tests
+        run: cd main/build && ctest
+
   macos:
     name: macOS x64 ${{matrix.cfg.name}}
     runs-on: ${{matrix.cfg.os}}
@@ -56,6 +59,9 @@ jobs:
 
       - name: Build Project
         run: cd main/build && ninja
+
+      - name: Run Tests
+        run: cd main/build && ctest
 
   windows: # Windows x64 and x86 build matrix
     strategy:
@@ -83,3 +89,6 @@ jobs:
 
       - name: Build Project
         run: cmake --build main/build
+
+      - name: Run Tests
+        run: cd main/build && ctest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,14 @@ jobs:
         with:
           arch: ${{ matrix.cfg.arch }}
 
+      - name: Install chocolatey packages (i386)
+        if: ${{ matrix.cfg.arch == 'x86' }}
+        run: choco install ninja -y --x86
+
+      - name: Install chocolatey packages (x64)
+        if: ${{ matrix.cfg.arch == 'x64' }}
+        run: choco install ninja -y
+
       - name: Generate CMake
         run: mkdir main/build && cd main/build && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DINFOWARE_EXAMPLES=ON -DINFOWARE_TESTS=ON ..
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,18 +4,13 @@ on:
   pull_request:
 
 jobs:
-  linux-x64:
-    name: Linux x64 (${{matrix.cfg.cpp-version}})
-    runs-on: ${{matrix.cfg.os}}
+  linux:
+    name: Linux x64 (${{matrix.cpp-version}})
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:
-        cfg:
-          - { os: ubuntu-18.04, cpp-version: g++-8 }
-          - { os: ubuntu-18.04, cpp-version: g++-9 }
-          - { os: ubuntu-18.04, cpp-version: clang++-7 }
-          - { os: ubuntu-18.04, cpp-version: clang++-8 }
-          - { os: ubuntu-18.04, cpp-version: clang++-9 }
+        cpp-version: [g++, clang++]
 
     steps:
       - name: Checkout infoware
@@ -24,12 +19,12 @@ jobs:
           path: main
 
       - name: Install apt packages
-        run: sudo apt update && sudo apt install -y cmake ${{ matrix.cfg.cpp-version }} ninja-build ocl-icd-opencl-dev
+        run: sudo apt update && sudo apt install -y cmake ninja-build ocl-icd-opencl-dev
 
       - name: Generate CMake
         run: mkdir main/build && cd main/build && cmake -DCMAKE_BUILD_TYPE=Release -DINFOWARE_USE_OPENCL=ON -DINFOWARE_EXAMPLES=ON -DINFOWARE_TESTS=ON -G Ninja ..
         env:
-          CXX: ${{matrix.cfg.cpp-version}}
+          CXX: ${{matrix.cpp-version}}
 
       - name: Build Project
         run: cd main/build && ninja

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,13 +65,13 @@ jobs:
       - name: Run Tests
         run: cd main/build && ctest
 
-  windows: # Windows x64 and x86 build matrix
+  windows: # Windows x64 and i386 build matrix
     strategy:
       fail-fast: false # Don't cancel other matrix jobs if one fails
       matrix:
         cfg:
-        - { name: 32 Bit, arch: x86 }
-        - { name: 64 Bit, arch: x64 }
+        - { name: i386,   arch: x86, chocoargs: "--x86"}
+        - { name: amd64,  arch: x64, chocoargs: ""}
 
     name: "Windows MSVC ${{matrix.cfg.name}}"
     runs-on: windows-2019
@@ -86,13 +86,8 @@ jobs:
         with:
           arch: ${{ matrix.cfg.arch }}
 
-      - name: Install chocolatey packages (x86)
-        if: ${{ matrix.cfg.arch == 'x86' }}
-        run: choco install ninja -y --x86
-
-      - name: Install chocolatey packages (x64)
-        if: ${{ matrix.cfg.arch == 'x64' }}
-        run: choco install ninja -y
+      - name: Install chocolatey packages (${{ matrix.cfg.name }})
+        run: choco install ninja -y ${{ matrix.cfg.chocargs }}
 
       - name: Generate CMake
         run: mkdir main/build && cd main/build && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DINFOWARE_EXAMPLES=ON -DINFOWARE_TESTS=ON ..

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   linux:
-    name: Linux x64 (${{matrix.cpp-version}})
+    name: Ubuntu 18.04 amd64 (${{matrix.cpp-version}})
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,21 +16,21 @@ jobs:
       - name: Checkout infoware
         uses: actions/checkout@v2
         with:
-          path: main
+          path: infoware
 
       - name: Install apt packages
         run: sudo apt update && sudo apt install -y cmake ninja-build ocl-icd-opencl-dev
 
       - name: Generate CMake
-        run: mkdir main/build && cd main/build && cmake -DCMAKE_BUILD_TYPE=Release -DINFOWARE_USE_OPENCL=ON -DINFOWARE_EXAMPLES=ON -DINFOWARE_TESTS=ON -G Ninja ..
+        run: mkdir infoware/build && cd infoware/build && cmake -DCMAKE_BUILD_TYPE=Release -DINFOWARE_USE_OPENCL=ON -DINFOWARE_EXAMPLES=ON -DINFOWARE_TESTS=ON -G Ninja ..
         env:
           CXX: ${{matrix.cpp-version}}
 
       - name: Build Project
-        run: cmake --build main/build
+        run: cmake --build infoware/build
 
       - name: Run Tests
-        run: ctest --test-dir main/build
+        run: ctest --test-dir infoware/build
 
   macos:
     name: macOS amd64 ${{matrix.cfg.name}}
@@ -46,19 +46,19 @@ jobs:
       - name: Checkout infoware
         uses: actions/checkout@v2
         with:
-          path: main
+          path: infoware
 
       - name: Install homebrew packages
         run: brew install cmake ninja openssl
 
       - name: Generate CMake
-        run: mkdir main/build && cd main/build && cmake -DCMAKE_BUILD_TYPE=Release -DINFOWARE_USE_OPENCL=ON -DINFOWARE_EXAMPLES=ON -DINFOWARE_TESTS=ON -G Ninja ..
+        run: mkdir infoware/build && cd infoware/build && cmake -DCMAKE_BUILD_TYPE=Release -DINFOWARE_USE_OPENCL=ON -DINFOWARE_EXAMPLES=ON -DINFOWARE_TESTS=ON -G Ninja ..
 
       - name: Build Project
-        run: cmake --build main/build
+        run: cmake --build infoware/build
 
       - name: Run Tests
-        run: ctest --test-dir main/build
+        run: ctest --test-dir infoware/build
 
   windows: # Windows amd64 and i386 build matrix
     strategy:
@@ -74,7 +74,7 @@ jobs:
       - name: Checkout infoware
         uses: actions/checkout@v2
         with:
-          path: main
+          path: infoware
 
       - name: Configure MSBuild
         uses: ilammy/msvc-dev-cmd@v1
@@ -85,10 +85,10 @@ jobs:
         run: choco install ninja -y ${{ matrix.cfg.chocargs }}
 
       - name: Generate CMake
-        run: mkdir main/build && cd main/build && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DINFOWARE_EXAMPLES=ON -DINFOWARE_TESTS=ON ..
+        run: mkdir infoware/build && cd infoware/build && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DINFOWARE_EXAMPLES=ON -DINFOWARE_TESTS=ON ..
 
       - name: Build Project
-        run: cmake --build main/build
+        run: cmake --build infoware/build
 
       - name: Run Tests
-        run: ctest --test-dir main/build
+        run: ctest --test-dir infoware/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
           CXX: ${{matrix.cpp-version}}
 
       - name: Build Project
-        run: cd main/build && ninja
+        run: cmake --build main/build
 
       - name: Run Tests
-        run: cd main/build && ctest
+        run: ctest --test-dir main/build
 
   macos:
     name: macOS x64 ${{matrix.cfg.name}}
@@ -55,10 +55,10 @@ jobs:
         run: mkdir main/build && cd main/build && cmake -DCMAKE_BUILD_TYPE=Release -DINFOWARE_USE_OPENCL=ON -DINFOWARE_EXAMPLES=ON -DINFOWARE_TESTS=ON -G Ninja ..
 
       - name: Build Project
-        run: cd main/build && ninja
+        run: cmake --build main/build
 
       - name: Run Tests
-        run: cd main/build && ctest
+        run: ctest --test-dir main/build
 
   windows: # Windows x64 and i386 build matrix
     strategy:
@@ -91,4 +91,4 @@ jobs:
         run: cmake --build main/build
 
       - name: Run Tests
-        run: cd main/build && ctest
+        run: ctest --test-dir main/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,12 @@ jobs:
           path: main
 
       - name: Install apt packages
-        run: sudo apt update && sudo apt install -y cmake ninja-build ocl-icd-opencl-dev
+        run: sudo apt update && sudo apt install -y cmake ${{ matrix.cfg.cpp-version }} ninja-build ocl-icd-opencl-dev
 
       - name: Generate CMake
         run: mkdir main/build && cd main/build && cmake -DCMAKE_BUILD_TYPE=Release -DINFOWARE_USE_OPENCL=ON -DINFOWARE_EXAMPLES=ON -DINFOWARE_TESTS=ON -G Ninja ..
+        env:
+          CXX: ${{matrix.cfg.cpp-version}}
 
       - name: Build Project
         run: cd main/build && ninja

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: infoware CI
+on:
+  push:
+  pull_request:
+
+jobs:
+  linux-x64:
+    name: Linux x64 (${{matrix.cfg.cpp-version}})
+    runs-on: ${{matrix.cfg.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        cfg:
+          - { os: ubuntu-18.04, cpp-version: g++-8 }
+          - { os: ubuntu-18.04, cpp-version: g++-9 }
+          - { os: ubuntu-18.04, cpp-version: clang++-7 }
+          - { os: ubuntu-18.04, cpp-version: clang++-8 }
+          - { os: ubuntu-18.04, cpp-version: clang++-9 }
+
+    steps:
+      - name: Checkout infoware
+        uses: actions/checkout@v2
+        with:
+          path: main
+
+      - name: Install apt packages
+        run: sudo apt update && sudo apt install -y cmake ninja-build ocl-icd-opencl-dev
+
+      - name: Generate CMake
+        run: mkdir main/build && cd main/build && cmake -DCMAKE_BUILD_TYPE=Release -DINFOWARE_USE_OPENCL=ON -DINFOWARE_EXAMPLES=ON -DINFOWARE_TESTS=ON -G Ninja ..
+
+      - name: Build Project
+        run: cd main/build && ninja

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: ctest --test-dir main/build
 
   macos:
-    name: macOS x64 ${{matrix.cfg.name}}
+    name: macOS amd64 ${{matrix.cfg.name}}
     runs-on: ${{matrix.cfg.os}}
     strategy:
       fail-fast: false
@@ -60,7 +60,7 @@ jobs:
       - name: Run Tests
         run: ctest --test-dir main/build
 
-  windows: # Windows x64 and i386 build matrix
+  windows: # Windows amd64 and i386 build matrix
     strategy:
       fail-fast: false # Don't cancel other matrix jobs if one fails
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           arch: ${{ matrix.cfg.arch }}
 
-      - name: Install chocolatey packages (i386)
+      - name: Install chocolatey packages (x86)
         if: ${{ matrix.cfg.arch == 'x86' }}
         run: choco install ninja -y --x86
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@
 !include/**
 !tools
 !tools/**
-!.git*
+!.gitignore
+!.github/**
 !.clang-format
 !.travis.yml
 !appveyor.yml

--- a/README.md
+++ b/README.md
@@ -1,9 +1,4 @@
-<p>
-	<h1>infoware</h1>
-	<a href="LICENSE"><img src="https://img.shields.io/badge/license-CC0-green.svg?style=flat"/></a>
-	<a href="https://github.com/ThePhD/infoware/actions/workflows/ci.yml"><img src="https://github.com/ThePhD/infoware/actions/workflows/ci.yml/badge.svg"/></a>
-</p>
-
+# infoware [![License](//img.shields.io/badge/license-CC0-green.svg?style=flat)](LICENSE) [![CI status](//github.com/ThePhD/infoware/actions/workflows/ci.yml/badge.svg)](//github.com/ThePhD/infoware/actions/workflows/ci.yml)
 
 C++ Library for pulling system and hardware information, without hitting the command line.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# infoware [![License](https://img.shields.io/badge/license-CC0-green.svg?style=flat)](LICENSE) [![TravisCI build status](https://travis-ci.org/ThePhD/infoware.svg?branch=master)](https://travis-ci.org/ThePhD/infoware) [![AppVeyorCI build status](https://ci.appveyor.com/api/projects/status/github/ThePhD/infoware?branch=master&svg=true)](https://ci.appveyor.com/project/ThePhD/infoware/branch/master)
+<p>
+	<h1>infoware</h1>
+	<a href="LICENSE"><img src="https://img.shields.io/badge/license-CC0-green.svg?style=flat"/></a>
+	<a href="https://github.com/ThePhD/infoware/actions/workflows/ci.yml"><img src="https://github.com/ThePhD/infoware/actions/workflows/ci.yml/badge.svg"/></a>
+</p>
+
+
 C++ Library for pulling system and hardware information, without hitting the command line.
 
 


### PR DESCRIPTION
# CI for infoware 🛠️

My intention is to build on all three platforms as I mentioned in #47. I noticed that someone had already made PR #57 before I had the chance to make this PR, thought I wanted to still share what I created, and let the maintainers choose if they would like to merge.

The main differences, is that I use one `.yml` file for all three operating systems. In my experience, it simplifies seeing which build failed and for which commit, verses when they are in two separate files, and you have to look at two separate separate GHA detail pages.

The only idea I pulled from #57 is adding the build status badges to the `README.md`. I did switch to use HTML only for the top portion with the `infoware` header, and `a` and `img` tags for the badges. In my opinion it looks cleaner that having all the badge+header info on a single line, though if this is not desired, I'm happy to revert the commit. *(Regaurdless of switching or not, until a PR is merged, and an action CI is run on ThePhD's page, the badge on the `README.md` won't properly show a badge)*

I was able to use ninja all three OS's. It's was able to notably cut down on my compile times for my other projects, so it's a go-to for most projects.

I was unsure what the desired CMake variable settings were, so I went with:
- `INFOWARE_USE_OPENCL=ON` (Except Windows)
- `INFOWARE_EXAMPLES=ON`
- `INFOWARE_TESTS=ON`

Please let me know if I should make any changes!