### PR TITLE
Fix CMake export containing reference to missing target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,9 +77,11 @@ set_target_properties(infoware PROPERTIES CXX_STANDARD 14
                                           RELWITHDEBINFO_POSTFIX "rwdi")
 
 target_compile_definitions(infoware PRIVATE INFOWARE_VERSION="${infoware_version}"
-                                            INFOWARE_BUILDING=1
-                                    PUBLIC $<$<STREQUAL:$<TARGET_PROPERTY:infoware,TYPE>,SHARED_LIBRARY>:INFOWARE_DLL=1>)
+                                            INFOWARE_BUILDING=1)
 
+if (BUILD_SHARED_LIBS)
+	target_compile_definitions(infoware PUBLIC "INFOWARE_DLL=1")
+endif()
 
 if(NOT Git_FOUND)  # Could be pre-injected
 	find_package(Git)


### PR DESCRIPTION
Hi,

CMake causes issues on Windows because the generated export inherits a string from the build script that contains generator expressions that are successfully evaluated at generation time, but they cannot be evaluated at import time (due to the missing target).

The generated code in `infowareConfig.cmake` looks like this, with the escaped expression from the generation script:

```
set_target_properties(infoware PROPERTIES
  INTERFACE_COMPILE_DEFINITIONS "\$<\$<STREQUAL:\$<TARGET_PROPERTY:infoware,TYPE>,SHARED_LIBRARY>:INFOWARE_DLL=1>"
  ...
)
```

This commit replaces the generator expression with a plain condition based on BUILD_SHARED_LIBS, which already controls the behavior of `add_library` used earlier.

This changes the content of the import script with:

```
set_target_properties(infoware PROPERTIES
  INTERFACE_COMPILE_DEFINITIONS "INFOWARE_DLL=1"
  ...
)
```

(when building a shared library, otherwise INFOWARE_DLL is not defined).

This fixes the import on Windows.
