### PR TITLE
[windows] retrieve logical DPI, physical resolution and more display information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ if(WIN32 AND NOT MSVC)
 endif()
 
 if(WIN32)
-	target_link_libraries(infoware PRIVATE gdi32 version Ole32 OleAut32 wbemuuid ntdll)
+	target_link_libraries(infoware PRIVATE gdi32 version Ole32 OleAut32 wbemuuid ntdll Shcore)
 endif()
 
 

--- a/examples/system.cpp
+++ b/examples/system.cpp
@@ -16,6 +16,7 @@
 
 
 static const char* kernel_variant_name(iware::system::kernel_t variant) noexcept;
+static const char* orientation_name(iware::system::orientation_t o) noexcept;
 
 
 int main() {
@@ -69,9 +70,15 @@ int main() {
 				const auto& display = displays[i];
 				std::cout << "    #" << (i + 1) << ":\n"
 				          << "      Resolution  : " << display.width << 'x' << display.height << '\n'
-				          << "      DPI         : " << display.dpi << '\n'
+				          << "      Logical DPI : " << display.dpi << '\n'
 				          << "      Colour depth: " << display.bpp << "b\n"
 				          << "      Refresh rate: " << display.refresh_rate << "Hz\n";
+#ifdef _WIN32
+				std::cout << "      Position    : " << display.x << ", " << display.y << '\n'
+				          << "      Scale factor: " << static_cast<int>(display.scale * 100) << "%\n"
+				          << "      Primary     : " << display.primary << '\n'
+				          << "      Orientation : " << orientation_name(display.orientation) << '\n';
+#endif  // _WIN32
 			}
 	}
 
@@ -119,6 +126,21 @@ static const char* kernel_variant_name(iware::system::kernel_t variant) noexcept
 			return "Linux";
 		case iware::system::kernel_t::darwin:
 			return "Darwin";
+		default:
+			return "Unknown";
+	}
+}
+
+static const char* orientation_name(iware::system::orientation_t o) noexcept {
+	switch(o) {
+		case iware::system::orientation_t::rotate_0:
+			return "Landscape";
+		case iware::system::orientation_t::rotate_90:
+			return "Portrait";
+		case iware::system::orientation_t::rotate_180:
+			return "Landscape (flipped)";
+		case iware::system::orientation_t::rotate_270:
+			return "Portrait (flipped)";
 		default:
 			return "Unknown";
 	}

--- a/include/infoware/system.hpp
+++ b/include/infoware/system.hpp
@@ -58,6 +58,13 @@ namespace iware {
 			unsigned int build_number;
 		};
 
+		enum class orientation_t {
+			rotate_0   = 0x01,
+			rotate_90  = 0x02,
+			rotate_180 = 0x04,
+			rotate_270 = 0x08,
+		};
+
 		struct display_t {
 			std::uint32_t width;
 			std::uint32_t height;
@@ -65,6 +72,13 @@ namespace iware {
 			/// Bits Per Pixel a.k.a. depth
 			std::uint32_t bpp;
 			double refresh_rate;
+#ifdef _WIN32
+			std::int32_t x;
+			std::int32_t y;
+			double scale;
+			bool primary;
+			orientation_t orientation;
+#endif  // _WIN32
 		};
 
 		struct display_config_t {

--- a/src/system/displays/displays_windows.cpp
+++ b/src/system/displays/displays_windows.cpp
@@ -40,8 +40,8 @@ static UINT retrieve_dpi_for_monitor(HMONITOR monitor) {
 		auto PRE_DAC = set_dpi_awareness(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
 		iware::detail::quickscope_wrapper dpi_awareness_resetter{[&]() { set_dpi_awareness(PRE_DAC); }};
 
-		// DPI_AWARENESS_CONTEXT_UNAWARE	             : 96 because the app is unaware of any other scale factors.
-		// DPI_AWARENESS_CONTEXT_SYSTEM_AWARE	         : A value set to the system DPI because the app assumes all applications use the system DPI.
+		// DPI_AWARENESS_CONTEXT_UNAWARE                 : 96 because the app is unaware of any other scale factors.
+		// DPI_AWARENESS_CONTEXT_SYSTEM_AWARE            : A value set to the system DPI because the app assumes all applications use the system DPI.
 		// DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE(_V2)  : The actual DPI value set by the user for that display.
 		if(::GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &dpi, &_) == S_OK) {  // Minimum supported clien: Windows 8.1
 			return dpi;
@@ -72,7 +72,7 @@ std::vector<iware::system::display_t> iware::system::displays() {
 		// we will set thread dpi awareness to block the influence of global dpi awareness settings, 
 		// such as Qt, SetProcessDPIAware, SetProcessDpiAwarenessContext.
 		if(set_dpi_awareness != nullptr) {
-			PRE_DAC = set_dpi_awareness(DPI_AWARENESS_CONTEXT_UNAWARE);  // make GetMonitorInfoA to get virtual resolution for computing the scale factor
+			PRE_DAC = set_dpi_awareness(DPI_AWARENESS_CONTEXT_UNAWARE);  // make GetMonitorInfo to get virtual resolution for computing the scale factor
 		}
 	}
 
@@ -92,17 +92,17 @@ std::vector<iware::system::display_t> iware::system::displays() {
 	    [](auto monitor, auto, auto, auto userdata) {
 		    auto& ret = *reinterpret_cast<std::vector<iware::system::display_t>*>(userdata);
 
-		    MONITORINFOEXA info{};
-		    info.cbSize = sizeof(MONITORINFOEXA);
-		    // GetMonitorInfoA will be affected by DPI_AWARENESS
+		    MONITORINFOEX info{};
+		    info.cbSize = sizeof(MONITORINFOEX);
+		    // GetMonitorInfo will be affected by DPI_AWARENESS
 		    // DPI_AWARENESS_CONTEXT_UNAWARE                : virtual resolution
 		    // DPI_AWARENESS_CONTEXT_SYSTEM_AWARE           : virtual resolution
 		    // DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE(_V2) : physical resolution
-		    if(::GetMonitorInfoA(monitor, &info)) {
-			    DEVMODEA settings = {};
-			    settings.dmSize   = sizeof(DEVMODEA);
+		    if(::GetMonitorInfo(monitor, &info)) {
+			    DEVMODE settings = {};
+			    settings.dmSize   = sizeof(DEVMODE);
 
-			    if(::EnumDisplaySettingsA(info.szDevice, ENUM_CURRENT_SETTINGS, &settings)) {  // not affected by DPI_AWARENESS
+			    if(::EnumDisplaySettings(info.szDevice, ENUM_CURRENT_SETTINGS, &settings)) {  // not affected by DPI_AWARENESS
 				    ret.push_back(
 				        {settings.dmPelsWidth, settings.dmPelsHeight, retrieve_dpi_for_monitor(monitor), settings.dmBitsPerPel,
 				         static_cast<double>(settings.dmDisplayFrequency), static_cast<std::int32_t>(settings.dmPosition.x),


### PR DESCRIPTION
As described in the issue #66 , the infoware can not retrieve correct **logical DPI** and **physical resolution** of each display:
Before:
```
Displays:
    #1:
      Resolution  : 2560x1440
      DPI         : 96
      Colour depth: 32b
      Refresh rate: 59Hz
    #2:
      Resolution  : 1280x720
      DPI         : 96
      Colour depth: 32b
      Refresh rate: 50Hz
```
Now:
```
  Displays:
    #1:
      Resolution  : 2560x1440
      Logical DPI : 96
      Colour depth: 32b
      Refresh rate: 59Hz
      Position    : 0, 0
      Scale factor: 100%
      Primary     : 1
      Orientation : Landscape
    #2:
      Resolution  : 1920x1080
      Logical DPI : 144
      Colour depth: 32b
      Refresh rate: 50Hz
      Position    : -1079, -1080
      Scale factor: 150%
      Primary     : 0
      Orientation : Landscape (flipped)
```

The behavior:

- `>= Windows 10 1607` : works fine
- `<  Windows 10 1607` : the values of  **Logical DPI**  and **Scale factor** depend on the global DPI avareness setting
- `<  Windows     8.1` : needs tests
