### PR TITLE
fix dpi calculation for linux & mac

### DIFF
--- a/src/system/displays/displays_darwin.cpp
+++ b/src/system/displays/displays_darwin.cpp
@@ -40,7 +40,7 @@ std::vector<iware::system::display_t> iware::system::displays() {
 	return enumerate_displays<iware::system::display_t>([](auto display_id) {
 		const std::uint32_t width = CGDisplayPixelsWide(display_id);
 		// 25.4 millimeters per inch
-		const std::uint32_t dpi = 25.4 * CGDisplayScreenSize(display_id).width / width;
+		const std::uint32_t dpi = width / (CGDisplayScreenSize(display_id).width / 25.4);
 
 		auto display_mode = CGDisplayCopyDisplayMode(display_id);
 		iware::detail::quickscope_wrapper display_mode_deleter{[&]() { CGDisplayModeRelease(display_mode); }};

--- a/src/system/displays/displays_x11.cpp
+++ b/src/system/displays/displays_x11.cpp
@@ -50,7 +50,7 @@ std::vector<iware::system::display_t> iware::system::displays() {
 		    width,
 		    static_cast<std::uint32_t>(DisplayHeight(display, screen_number)),
 		    // 25.4 millimeters per inch
-		    static_cast<std::uint32_t>(25.4 * DisplayWidthMM(display, screen_number) / width),
+		    static_cast<std::uint32_t>(width / (DisplayWidthMM(display, screen_number) / 25.4)),
 		    static_cast<std::uint32_t>(DefaultDepth(display, screen_number)),
 		    static_cast<double>(XRRConfigCurrentRate(screen_config)),
 		};


### PR DESCRIPTION
fix dpi calculation for linux & mac

DPI = pixels / inch, not mm / pixels
dots = pixels for computer screens