### PR TITLE
Small fix in OS_info for windows; CMakeLists.txt - add config option to exclude PCI easily 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.6.0)
 
 
-set(infoware_version "0.6.0")
+set(infoware_version "0.6.1")
 
 project(infoware VERSION "${infoware_version}" LANGUAGES CXX)
 
@@ -16,6 +16,8 @@ option(INFOWARE_USE_OPENGL "Add public, transitive define to infoware to use Ope
 option(INFOWARE_USE_OPENCL "Add public, transitive define to infoware to use Open Compute Language (OpenCL) for GPU detection."  OFF)
 
 option(INFOWARE_USE_X11 "Add public, transitive define to infoware to use X11 for display detection." OFF)
+
+option(INFOWARE_USE_PCIIDS "Want PCI IDs. If false, database of PCI IDs and functions in pci.hpp will not be available"          ON)
 
 option(INFOWARE_EXAMPLES "Add infoware examples to the build." OFF)
 option(INFOWARE_TESTS    "Input tests for infoware."           OFF)
@@ -59,6 +61,11 @@ if(INFOWARE_USE_OPENGL AND APPLE)
 endif()
 
 file(GLOB_RECURSE infoware_source_files    LIST_DIRECTORIES false CONFIGURE_DEPENDS src/*.cpp)
+
+if(NOT INFOWARE_USE_PCIIDS)
+   list(FILTER infoware_source_files EXCLUDE REGEX ".*pci\\.cpp")
+endif()
+
 if(APPLE)
       file(GLOB_RECURSE infoware_objc_source_files LIST_DIRECTORIES FALSE CONFIGURE_DEPENDS src/*.mm)
       list(APPEND infoware_source_files ${infoware_objc_source_files})
@@ -91,6 +98,7 @@ if(BUILD_SHARED_LIBS)  # Controls add_library() w/o explicit mode
 	target_compile_definitions(infoware PUBLIC INFOWARE_DLL=1)
 endif()
 
+if(INFOWARE_USE_PCIIDS)
 if(NOT Git_FOUND)  # Could be pre-injected
 	find_package(Git)
 endif()
@@ -152,7 +160,7 @@ else()
 	                    CMAKE_ARGS -DINFOWARE_PCI_DATA_DIR:PATH=${CMAKE_BINARY_DIR}/${INFOWARE_PCI_DATA_DIR})
 endif()
 add_dependencies(infoware infoware_generate_pcis)
-
+endif(INFOWARE_USE_PCIIDS)
 
 if(MSVC)
 	# Only CMake 3.15.0 makes this stuff not necessary, but we have a shitty

--- a/src/system/OS_info/os_info_windows.cpp
+++ b/src/system/OS_info/os_info_windows.cpp
@@ -54,7 +54,7 @@ static std::string version_name() {
 
 	IEnumWbemClassObject* query_iterator_raw;
 	wchar_t query_lang[] = L"WQL";
-	wchar_t query[]      = L"SELECT Name FROM Win32_OperatingSystem";
+	wchar_t query[]      = L"SELECT Caption FROM Win32_OperatingSystem";
 	if(FAILED(wbem_services->ExecQuery(query_lang, query, WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY, nullptr, &query_iterator_raw)))
 		return {};
 	std::unique_ptr<IEnumWbemClassObject, iware::detail::release_deleter> query_iterator(query_iterator_raw);
@@ -70,15 +70,13 @@ static std::string version_name() {
 		std::unique_ptr<IWbemClassObject, iware::detail::release_deleter> value(value_raw);
 
 		VARIANT val;
-		value->Get(L"Name", 0, &val, 0, 0);
+		VariantInit(&val);
+		value->Get(L"Caption", 0, &val, 0, 0);
 		iware::detail::quickscope_wrapper val_destructor{[&] { VariantClear(&val); }};
 
 		ret = iware::detail::narrowen_bstring(val.bstrVal);
 	}
 
-	const auto sep = ret.find('|');
-	if(sep != std::string::npos)
-		ret.resize(sep);
 	return ret;
 }
 


### PR DESCRIPTION
* Mute c++ warning; small optimization in OS_info for windows; 
* CMakeLists.txt - add config option to exclude PCI easily 
  * Version increased to 0.6.1 
  
In os_info_windows.cpp, `version_name()` : 
 - `VARIANT val` should be initialized, VC++ compiler warning on `val_destructor` because of uninitialized inout param.
 - In WMI query get `Capture`, not `Name`. No need to find & resize string.
