### PR TITLE
Make easy to exclude PCI ids functionality in  CMakeLists.txt 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.6.0)
 
 
-set(infoware_version "0.6.0")
+set(infoware_version "0.6.1")
 
 project(infoware VERSION "${infoware_version}" LANGUAGES CXX)
 
@@ -16,6 +16,8 @@ option(INFOWARE_USE_OPENGL "Add public, transitive define to infoware to use Ope
 option(INFOWARE_USE_OPENCL "Add public, transitive define to infoware to use Open Compute Language (OpenCL) for GPU detection."  OFF)
 
 option(INFOWARE_USE_X11 "Add public, transitive define to infoware to use X11 for display detection." OFF)
+
+option(INFOWARE_USE_PCIIDS "Want PCI IDs. If OFF database of PCI IDs and functions in pci.hpp will not be available"             ON)
 
 option(INFOWARE_EXAMPLES "Add infoware examples to the build." OFF)
 option(INFOWARE_TESTS    "Input tests for infoware."           OFF)
@@ -59,6 +61,7 @@ if(INFOWARE_USE_OPENGL AND APPLE)
 endif()
 
 file(GLOB_RECURSE infoware_source_files    LIST_DIRECTORIES false CONFIGURE_DEPENDS src/*.cpp)
+
 if(APPLE)
       file(GLOB_RECURSE infoware_objc_source_files LIST_DIRECTORIES FALSE CONFIGURE_DEPENDS src/*.mm)
       list(APPEND infoware_source_files ${infoware_objc_source_files})
@@ -90,6 +93,9 @@ target_compile_definitions(infoware PRIVATE INFOWARE_VERSION="${infoware_version
 if(BUILD_SHARED_LIBS)  # Controls add_library() w/o explicit mode
 	target_compile_definitions(infoware PUBLIC INFOWARE_DLL=1)
 endif()
+
+if(INFOWARE_USE_PCIIDS)
+target_compile_definitions(infoware PUBLIC INFOWARE_USE_PCIIDS)
 
 if(NOT Git_FOUND)  # Could be pre-injected
 	find_package(Git)
@@ -152,7 +158,7 @@ else()
 	                    CMAKE_ARGS -DINFOWARE_PCI_DATA_DIR:PATH=${CMAKE_BINARY_DIR}/${INFOWARE_PCI_DATA_DIR})
 endif()
 add_dependencies(infoware infoware_generate_pcis)
-
+endif(INFOWARE_USE_PCIIDS)
 
 if(MSVC)
 	# Only CMake 3.15.0 makes this stuff not necessary, but we have a shitty

--- a/examples/pci.cpp
+++ b/examples/pci.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: CC0-1.0
 // infoware - C++ System information Library
 
+#ifdef INFOWARE_USE_PCIIDS
 
 #include "infoware/pci.hpp"
 #include "infoware/version.hpp"
@@ -66,3 +67,14 @@ static bool print_vendor(std::uint64_t vendor_id, const char* vendor_name) {
 
 	return vendor_name;
 }
+
+#else //INFOWARE_USE_PCIIDS
+#include "infoware/version.hpp"
+#include <iostream>
+
+int main(int, const char** argv) {
+	std::cout << "Infoware version " << iware::version << '\n';
+	std::cout << "Compiled without PCI IDs support" << '\n';
+}
+#endif //INFOWARE_USE_PCIIDS
+

--- a/src/pci.cpp
+++ b/src/pci.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: CC0-1.0
 // infoware - C++ System information Library
 
+#ifdef INFOWARE_USE_PCIIDS
 
 #include "infoware/pci.hpp"
 #include "infoware_generated/pci_data.hpp"
@@ -62,3 +63,5 @@ const char* iware::pci::identify_vendor(std::uint64_t pci_id) noexcept {
 	else
 		return nullptr;
 }
+
+#endif //INFOWARE_USE_PCIIDS

--- a/src/system/OS_info/os_info_windows.cpp
+++ b/src/system/OS_info/os_info_windows.cpp
@@ -54,7 +54,7 @@ static std::string version_name() {
 
 	IEnumWbemClassObject* query_iterator_raw;
 	wchar_t query_lang[] = L"WQL";
-	wchar_t query[]      = L"SELECT Name FROM Win32_OperatingSystem";
+	wchar_t query[]      = L"SELECT Caption FROM Win32_OperatingSystem";
 	if(FAILED(wbem_services->ExecQuery(query_lang, query, WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY, nullptr, &query_iterator_raw)))
 		return {};
 	std::unique_ptr<IEnumWbemClassObject, iware::detail::release_deleter> query_iterator(query_iterator_raw);
@@ -70,15 +70,13 @@ static std::string version_name() {
 		std::unique_ptr<IWbemClassObject, iware::detail::release_deleter> value(value_raw);
 
 		VARIANT val;
-		value->Get(L"Name", 0, &val, 0, 0);
+		VariantInit(&val);
+		value->Get(L"Caption", 0, &val, 0, 0);
 		iware::detail::quickscope_wrapper val_destructor{[&] { VariantClear(&val); }};
 
 		ret = iware::detail::narrowen_bstring(val.bstrVal);
 	}
 
-	const auto sep = ret.find('|');
-	if(sep != std::string::npos)
-		ret.resize(sep);
 	return ret;
 }
 


### PR DESCRIPTION
The intent of exclusion of big blob in CMakeLists.txt by `if(INFOWARE_USE_PCIIDS)` is that it does lot of fuss with searching git, then clone something, compiling and running some utility.... all what users who do not want PCI IDs functionality even do not want to see.

Alternative is to provide small dummy `pci.ids` file and go build with it... but why.